### PR TITLE
Feature/54

### DIFF
--- a/src/main/java/kb_hack/backend/domain/email/controller/EmailController.java
+++ b/src/main/java/kb_hack/backend/domain/email/controller/EmailController.java
@@ -27,7 +27,7 @@ public class EmailController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "이메일 발송 성공",
                             content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
-                    @ApiResponse(responseCode = "500", description = "메일 서버 오류 / Redis 저장 오류")
+                    @ApiResponse(responseCode = "400", description = "이미 가입한 이메일 입니다 or 이메일 발송 실패 ")
             }
     )
     public SuccessResponse<Void>sendEmail(@RequestBody MailDTO mailDTO){

--- a/src/main/java/kb_hack/backend/domain/email/mapper/EmailMapper.java
+++ b/src/main/java/kb_hack/backend/domain/email/mapper/EmailMapper.java
@@ -1,0 +1,8 @@
+package kb_hack.backend.domain.email.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface EmailMapper {
+    int findMemberIDByEmail(String email);
+}

--- a/src/main/java/kb_hack/backend/domain/email/service/EmailService.java
+++ b/src/main/java/kb_hack/backend/domain/email/service/EmailService.java
@@ -2,6 +2,7 @@ package kb_hack.backend.domain.email.service;
 
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+import kb_hack.backend.domain.email.mapper.EmailMapper;
 import kb_hack.backend.global.common.exception.enums.BadStatusCode;
 import kb_hack.backend.global.common.exception.type.BadRequestException;
 import kb_hack.backend.global.common.exception.type.ServerErrorException;
@@ -25,8 +26,13 @@ public class EmailService {
     private final JavaMailSender emailSender;
     private final TemplateEngine templateEngine;
     private final StringRedisTemplate redisTemplate;
+    private final EmailMapper emailMapper;
 
     public void sendVerificationCode(String email) {
+        if (emailMapper.findMemberIDByEmail(email) != 0) {
+            throw new BadRequestException(BadStatusCode.ALREADY_REGISTERED_EMAIL_EXCEPTION);
+        }
+
         String verificationCode = generateCode();
         String key = email + ":email-verification";
 

--- a/src/main/java/kb_hack/backend/domain/member/controller/AuthController.java
+++ b/src/main/java/kb_hack/backend/domain/member/controller/AuthController.java
@@ -14,6 +14,7 @@ import kb_hack.backend.global.common.exception.enums.SuccessStatusCode;
 import kb_hack.backend.global.common.response.bad.BadResponse;
 import kb_hack.backend.global.common.response.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -69,6 +70,21 @@ public class AuthController {
         return SuccessResponse.makeResponse(SuccessStatusCode.SIGNOUT_SUCCESS);
     }
 
+    @Operation(
+            summary = "비밀번호 변경",
+            description = """
+            회원 이메일을 기반으로 새 비밀번호를 설정합니다.  
+            - 입력받은 비밀번호는 서버에서 BCrypt로 암호화되어 저장됩니다.  
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (이메일 없음, 비밀번호 누락 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PatchMapping("/password")
     public SuccessResponse<Void> changeNewPassword(@RequestBody LoginUpdateNewPassword loginUpdateNewPassword){
         memberService.updatePassword(loginUpdateNewPassword.getMemberEmail(),loginUpdateNewPassword.getPassword());

--- a/src/main/java/kb_hack/backend/domain/member/controller/AuthController.java
+++ b/src/main/java/kb_hack/backend/domain/member/controller/AuthController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kb_hack.backend.domain.member.dto.request.LoginUpdateNewPassword;
 import kb_hack.backend.domain.member.dto.request.SigunUpRequestDTO;
 import kb_hack.backend.domain.member.service.MemberService;
 import kb_hack.backend.global.common.exception.enums.SuccessStatusCode;
@@ -66,6 +67,12 @@ public class AuthController {
     public SuccessResponse<Void> signOutMember(){
         memberService.delete();
         return SuccessResponse.makeResponse(SuccessStatusCode.SIGNOUT_SUCCESS);
+    }
+
+    @PatchMapping("/password")
+    public SuccessResponse<Void> changeNewPassword(@RequestBody LoginUpdateNewPassword loginUpdateNewPassword){
+        memberService.updatePassword(loginUpdateNewPassword.getMemberEmail(),loginUpdateNewPassword.getPassword());
+        return SuccessResponse.makeResponse(SuccessStatusCode.CHANGE_NEW_PASSWORD_SUCCESS);
     }
 }
 

--- a/src/main/java/kb_hack/backend/domain/member/controller/AuthController.java
+++ b/src/main/java/kb_hack/backend/domain/member/controller/AuthController.java
@@ -71,7 +71,7 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "비밀번호 변경",
+            summary = "비밀번호 변경(로그인 페이지)",
             description = """
             회원 이메일을 기반으로 새 비밀번호를 설정합니다.  
             - 입력받은 비밀번호는 서버에서 BCrypt로 암호화되어 저장됩니다.  

--- a/src/main/java/kb_hack/backend/domain/member/controller/MemberInfoController.java
+++ b/src/main/java/kb_hack/backend/domain/member/controller/MemberInfoController.java
@@ -1,4 +1,51 @@
 package kb_hack.backend.domain.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kb_hack.backend.domain.member.dto.request.MemberInfoUpdateNewPassword;
+import kb_hack.backend.domain.member.service.MemberInfoService;
+import kb_hack.backend.domain.member.service.MemberService;
+import kb_hack.backend.global.common.exception.enums.SuccessStatusCode;
+import kb_hack.backend.global.common.response.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("")
+@RequiredArgsConstructor
+@Tag(name = "회원 정보 API (마이페이지)", description = "회원 비밀번호 변경 및 관련 기능을 제공합니다.")
 public class MemberInfoController {
+    private final MemberInfoService memberInfoService;
+
+    @Operation(
+            summary = "비밀번호 변경 API (마이페이지)",
+            description = """
+        로그인한 사용자가 기존 비밀번호를 검증한 뒤,
+        새로운 비밀번호로 변경합니다.
+        
+        - 기존 비밀번호(`originalPassword`)는 DB에 저장된 해시값과 비교됩니다.
+        - 새 비밀번호(`newPassword`)는 BCrypt로 암호화되어 저장됩니다.
+        - 성공 시 별도의 응답 데이터 없이 성공 코드만 반환됩니다.
+        """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "기존 비밀번호 불일치 또는 잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "DB 처리 중 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/password")
+    SuccessResponse<Void> changePassword(@RequestBody MemberInfoUpdateNewPassword memberInfoUpdateNewPassword){
+        memberInfoService.updatePassword(memberInfoUpdateNewPassword.getOriginalPassword(),memberInfoUpdateNewPassword.getNewPassword());
+        return SuccessResponse.makeResponse(SuccessStatusCode.CHANGE_NEW_PASSWORD_SUCCESS);
+    }
 }

--- a/src/main/java/kb_hack/backend/domain/member/controller/MemberInfoController.java
+++ b/src/main/java/kb_hack/backend/domain/member/controller/MemberInfoController.java
@@ -1,0 +1,4 @@
+package kb_hack.backend.domain.member.controller;
+
+public class MemberInfoController {
+}

--- a/src/main/java/kb_hack/backend/domain/member/dto/request/LoginUpdateNewPassword.java
+++ b/src/main/java/kb_hack/backend/domain/member/dto/request/LoginUpdateNewPassword.java
@@ -1,0 +1,13 @@
+package kb_hack.backend.domain.member.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class LoginUpdateNewPassword {
+    private String password;
+    private String memberEmail;
+}

--- a/src/main/java/kb_hack/backend/domain/member/dto/request/LoginUpdateNewPassword.java
+++ b/src/main/java/kb_hack/backend/domain/member/dto/request/LoginUpdateNewPassword.java
@@ -3,11 +3,15 @@ package kb_hack.backend.domain.member.dto.request;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LoginUpdateNewPassword {
-    private String password;
+    @Schema(description = "회원 이메일", example = "test@example.com")
     private String memberEmail;
+    @Schema(description = "새로운 비밀번호", example = "12345")
+    private String password;
+
 }

--- a/src/main/java/kb_hack/backend/domain/member/dto/request/MemberInfoUpdateNewPassword.java
+++ b/src/main/java/kb_hack/backend/domain/member/dto/request/MemberInfoUpdateNewPassword.java
@@ -1,0 +1,17 @@
+package kb_hack.backend.domain.member.dto.request;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class MemberInfoUpdateNewPassword {
+    @Schema(description = "기존 비밀번호", example = "12345")
+    private String originalPassword;
+    @Schema(description = "새로운 비밀번호", example = "12345")
+    private String newPassword;
+
+}

--- a/src/main/java/kb_hack/backend/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/kb_hack/backend/domain/member/mapper/MemberMapper.java
@@ -3,10 +3,12 @@ package kb_hack.backend.domain.member.mapper;
 import kb_hack.backend.domain.member.dto.AuthDTO;
 import kb_hack.backend.domain.member.dto.MemberDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface MemberMapper {
     int insertMember(MemberDTO memberDTO);
     int insertAuth(AuthDTO authDTO);
     int deleteUser(Long memberId);
+    int updatePasswordByMemberEmail(@Param("memberEmail") String memberEmail, @Param("newPassword")String newPassword);
 }

--- a/src/main/java/kb_hack/backend/domain/member/service/MemberInfoService.java
+++ b/src/main/java/kb_hack/backend/domain/member/service/MemberInfoService.java
@@ -1,0 +1,41 @@
+package kb_hack.backend.domain.member.service;
+
+import kb_hack.backend.domain.member.mapper.MemberMapper;
+import kb_hack.backend.global.common.exception.enums.BadStatusCode;
+import kb_hack.backend.global.common.exception.type.BadRequestException;
+import kb_hack.backend.global.common.exception.type.ServerErrorException;
+import kb_hack.backend.global.security.dto.SecurityCustomUser;
+import kb_hack.backend.global.security.entity.MemberVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInfoService {
+    private final MemberMapper memberMapper;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public void updatePassword(String OriginalPassword, String newPassword){
+        MemberVO vo = getMemberVO();
+        if (!bCryptPasswordEncoder.matches(OriginalPassword, vo.getPassword())) {
+            throw new BadRequestException(BadStatusCode.INCORRECT_ORIGINAL_PASSWORD_EXCEPTION);
+        }
+        System.out.println("vo.getPassword() = " + vo.getPassword());
+        String encode = bCryptPasswordEncoder.encode(newPassword);
+        int i = memberMapper.updatePasswordByMemberEmail(vo.getMemberEmail(), encode);
+
+        if (i == 0) {
+            throw new ServerErrorException(BadStatusCode.DATABASE_PROCESSING_EXCEPTION);
+        }
+    }
+
+    private static MemberVO getMemberVO() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        SecurityCustomUser securityUser = (SecurityCustomUser) authentication.getPrincipal();
+        MemberVO vo = securityUser.getMemberVO();
+        return vo;
+    }
+}

--- a/src/main/java/kb_hack/backend/domain/member/service/MemberService.java
+++ b/src/main/java/kb_hack/backend/domain/member/service/MemberService.java
@@ -75,14 +75,32 @@ public class MemberService {
     }
 
     public void delete (){
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        SecurityCustomUser securityUser = (SecurityCustomUser) authentication.getPrincipal();
-        MemberVO vo = securityUser.getMemberVO();
+        MemberVO vo = getMemberVO();
         int i = memberMapper.deleteUser(vo.getMemberId());
 
         if(i == 0 ) {
             throw new ServerErrorException(BadStatusCode.FAIL_TO_SIGNOUT_EXCEPTION);
         }
+    }
+
+
+    public void updatePassword(String memberEmail, String newPassword){
+        if (newPassword == null || newPassword.isBlank()) {
+            throw new BadRequestException(BadStatusCode.INVALID_PARAMETER_EXCEPTION);
+        }
+        String encode = bCryptPasswordEncoder.encode(newPassword);
+        int i = memberMapper.updatePasswordByMemberEmail(memberEmail, encode);
+
+        if (i == 0) {
+            throw new ServerErrorException(BadStatusCode.DATABASE_PROCESSING_EXCEPTION);
+        }
+    }
+
+    private static MemberVO getMemberVO() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        SecurityCustomUser securityUser = (SecurityCustomUser) authentication.getPrincipal();
+        MemberVO vo = securityUser.getMemberVO();
+        return vo;
     }
 
 

--- a/src/main/java/kb_hack/backend/domain/member/service/MemberService.java
+++ b/src/main/java/kb_hack/backend/domain/member/service/MemberService.java
@@ -85,7 +85,7 @@ public class MemberService {
 
 
     public void updatePassword(String memberEmail, String newPassword){
-        if (newPassword == null || newPassword.isBlank()) {
+        if (newPassword == null || newPassword.isBlank() || memberEmail == null || memberEmail.isBlank()) {
             throw new BadRequestException(BadStatusCode.INVALID_PARAMETER_EXCEPTION);
         }
         String encode = bCryptPasswordEncoder.encode(newPassword);

--- a/src/main/java/kb_hack/backend/global/common/exception/enums/BadStatusCode.java
+++ b/src/main/java/kb_hack/backend/global/common/exception/enums/BadStatusCode.java
@@ -18,6 +18,7 @@ public enum BadStatusCode {
     FAIL_TO_REGISTER_MEMBER_EXCEPTION(HttpStatus.BAD_REQUEST, "회원 등록에 실패했습니다. 요청 데이터를 확인해주세요."),
     INSUFFICIENT_EMAIL_VERIFICATION_CODE(HttpStatus.BAD_REQUEST,"인증번호가 존재하지 않거나 만료되었습니다."),
     INVAID_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST,"유효하지 않은 이메일 입니다."),
+    ALREADY_REGISTERED_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
 
 
     //401 UNAUTHORIZED

--- a/src/main/java/kb_hack/backend/global/common/exception/enums/BadStatusCode.java
+++ b/src/main/java/kb_hack/backend/global/common/exception/enums/BadStatusCode.java
@@ -19,6 +19,7 @@ public enum BadStatusCode {
     INSUFFICIENT_EMAIL_VERIFICATION_CODE(HttpStatus.BAD_REQUEST,"인증번호가 존재하지 않거나 만료되었습니다."),
     INVAID_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST,"유효하지 않은 이메일 입니다."),
     ALREADY_REGISTERED_EMAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+    INCORRECT_ORIGINAL_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST,"기존 비밀번호가 일치 하지 않습니다."),
 
 
     //401 UNAUTHORIZED

--- a/src/main/java/kb_hack/backend/global/common/exception/enums/SuccessStatusCode.java
+++ b/src/main/java/kb_hack/backend/global/common/exception/enums/SuccessStatusCode.java
@@ -18,7 +18,8 @@ public enum SuccessStatusCode {
     EMAIL_VERIFY_CODE_SUCCESS(HttpStatus.OK,"인증 코드 검증 성공!"),
     ANNOUNCE_GET_SUCCESS(HttpStatus.OK,"공고 리스트 불러오기 성공!"),
     FESTIVAL_GET_SUCCESS(HttpStatus.OK,"축제 리스트 불러오기 성공!"),
-    SIGNOUT_SUCCESS(HttpStatus.OK,"회원 탈퇴 성공!");
+    SIGNOUT_SUCCESS(HttpStatus.OK,"회원 탈퇴 성공!"),
+    CHANGE_NEW_PASSWORD_SUCCESS(HttpStatus.OK,"비밀번호 변경 성공!");
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/kb_hack/backend/global/security/config/SecurityConfig.java
+++ b/src/main/java/kb_hack/backend/global/security/config/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login","/auth/refresh","/auth/password","/check","/test/*","/email/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/member-info").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/auth/member-info").hasRole("Member")
+                        .requestMatchers(HttpMethod.DELETE, "/password").hasRole("Member")
                         .requestMatchers("/crawl/admin").hasRole("Admin")
 
                         .anyRequest().authenticated()

--- a/src/main/java/kb_hack/backend/global/security/config/SecurityConfig.java
+++ b/src/main/java/kb_hack/backend/global/security/config/SecurityConfig.java
@@ -74,10 +74,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth)-> auth
                         //스웨거,Welcome page 허용
                         .requestMatchers("/assets/**", "/favicon.ico", "/swagger-resources/**", "/swagger-ui.html", "/swagger-ui/**",
-                                "/webjars/**", "/swagger/**","/", "/index.html","/api-docs/**").permitAll()
+                                "/webjars/**", "/swagger/**","/", "/index.html","/api-docs/**","/images/logo.png").permitAll()
 
                         //실제 permitall 할 ul
-                        .requestMatchers("/auth/login","/auth/refresh","/auth/password","/check","/test/*","/email/**","/images/logo.png").permitAll()
+                        .requestMatchers("/auth/login","/auth/refresh","/auth/password","/check","/test/*","/email/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/auth/member-info").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/auth/member-info").hasRole("Member")
                         .requestMatchers("/crawl/admin").hasRole("Admin")

--- a/src/main/resources/mapper/EmailMapper.xml
+++ b/src/main/resources/mapper/EmailMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="kb_hack.backend.domain.email.mapper.EmailMapper">
+
+    <select id="findMemberIDByEmail" resultType="java.lang.Integer" parameterType="string">
+        select member_id
+        from member
+        where member_email=#{email}
+    </select>
+</mapper>
+

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -19,6 +19,13 @@
         where member_id = #{memberId}
     </delete>
 
+    <update id="updatePasswordByMemberEmail">
+        UPDATE member
+        SET password = #{newPassword}
+        WHERE member_email =#{memberEmail}
+
+    </update>
+
 
 
 </mapper>


### PR DESCRIPTION
<!--- 제목 ex: [Feat]: 회원가입 -->
회원가입 로직 구현 (마이페이지 , 로그인 페이지)
## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #54 
> Close #이슈번호

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- 로그인 페이지에서 비밀번호 찾기는 jwt 안주고 바로 비밀번호 변경한다
- 이때 이메일 중복 체크여부가 필요함으로 그 부분의 로직을 짰다
- 마이페이지에서 비밀번호 변경은 jwt를 보내줌으로 회원정보를 jwt 에서 찾는다


## 📸 이미지 (테스트 이미지 필수)
<img width="1147" height="751" alt="image" src="https://github.com/user-attachments/assets/858cb6af-be2d-4fdb-8dff-004cf2f1d9a0" />
<img width="1226" height="902" alt="image" src="https://github.com/user-attachments/assets/f902eafb-ed41-455e-8afd-2e29f5f4bab6" />


## ❓ 논의하고 싶은 내용

## 📍 레퍼런스
